### PR TITLE
Scaffold new models/stores

### DIFF
--- a/server/lib/helpers.ts
+++ b/server/lib/helpers.ts
@@ -37,7 +37,7 @@ export const checkRequestAuth: CheckRequestAuth = (authorization, logger) => {
     }
 
     if (!token) {
-      return null;
+      return resolve(null);
     }
 
     // Verify token with Firebase Admin SDK

--- a/server/lib/models/enums/brand-assets-status.enum.ts
+++ b/server/lib/models/enums/brand-assets-status.enum.ts
@@ -1,0 +1,5 @@
+export enum BrandAssetsStatus {
+  YES = 'yes',
+  PARTIAL = 'partial',
+  NO = 'no'
+}

--- a/server/lib/models/enums/is-501c3-status.enum.ts
+++ b/server/lib/models/enums/is-501c3-status.enum.ts
@@ -1,0 +1,5 @@
+export enum Is501c3Status {
+  YES = 'yes',
+  NO = 'no',
+  IN_PROGRESS = 'in-progress'
+}

--- a/server/lib/models/enums/onsite-contact-availability.enum.ts
+++ b/server/lib/models/enums/onsite-contact-availability.enum.ts
@@ -1,0 +1,5 @@
+export enum OnsiteContactAvailability {
+  IN_PERSON = 'in-person',
+  REMOTE = 'remote',
+  NONE = 'none'
+}

--- a/server/lib/models/enums/project-status.enum.ts
+++ b/server/lib/models/enums/project-status.enum.ts
@@ -1,0 +1,6 @@
+export enum ProjectStatus {
+  INTERESTED = 'interested',
+  ACCEPTED = 'accepted',
+  REJECTED = 'rejected',
+  ARCHIVED = 'archived'
+}

--- a/server/lib/models/enums/skill-importance.enum.ts
+++ b/server/lib/models/enums/skill-importance.enum.ts
@@ -1,0 +1,4 @@
+export enum SkillImportance {
+  REQUIRED = 'required',
+  NICE_TO_HAVE = 'nice-to-have'
+}

--- a/server/lib/models/enums/slot-status.enum.ts
+++ b/server/lib/models/enums/slot-status.enum.ts
@@ -1,0 +1,7 @@
+export enum SlotStatus {
+  OPEN = 'open',
+  INVITED = 'invited',
+  CONFIRMED = 'confirmed',
+  CONFIRMED_PARTIAL = 'confirmed-partial',
+  DECLINED = 'declined'
+}

--- a/server/lib/models/enums/user-role.enum.ts
+++ b/server/lib/models/enums/user-role.enum.ts
@@ -13,3 +13,12 @@ export const READ_ALL_EVENTS = [ UserRole.BOARDMEMBER, UserRole.ADMIN ];
 export const EDIT_ALL_EVENTS = [ UserRole.BOARDMEMBER, UserRole.ADMIN ];
 
 export const EDIT_ALL_SKILLS = [ UserRole.BOARDMEMBER, UserRole.ADMIN ];
+
+export const EDIT_ALL_NONPROFITS = [ UserRole.BOARDMEMBER, UserRole.ADMIN ];
+export const READ_NONPROFIT_PII = [ UserRole.BOARDMEMBER, UserRole.ADMIN ];
+
+export const EDIT_ALL_PROJECTS = [ UserRole.BOARDMEMBER, UserRole.ADMIN ];
+
+export const EDIT_ALL_POSITIONS = [ UserRole.BOARDMEMBER, UserRole.ADMIN ];
+
+export const EDIT_ALL_SLOTS = [ UserRole.BOARDMEMBER, UserRole.ADMIN ];

--- a/server/lib/models/event.ts
+++ b/server/lib/models/event.ts
@@ -11,6 +11,7 @@ export interface IEvent {
   additionalInfo: string,
   startDate: Date, // ISO date with time zone
   endDate: Date, // ISO date with time zone
+  rsvpDeadline?: Date, // ISO date with time zone; after this, volunteers can't change their RSVP
   location: string, // full address of event
   allowSignUps: boolean,
   allowPartialAttendance: boolean,
@@ -26,6 +27,7 @@ const eventSchema = new Schema<IEvent>({
   additionalInfo: String,
   startDate: { type: Date, required: true },
   endDate: { type: Date, required: true },
+  rsvpDeadline: Date,
   location: String,
   allowSignUps: Boolean,
   allowPartialAttendance: Boolean,

--- a/server/lib/models/nonprofit.ts
+++ b/server/lib/models/nonprofit.ts
@@ -1,0 +1,35 @@
+import { Schema, model, Types } from 'mongoose';
+import { MongooseOpts } from './default-opts';
+import { Is501c3Status } from './enums/is-501c3-status.enum';
+
+export interface INonprofit {
+  _id?: Types.ObjectId,
+  name: string,
+  website?: string,
+  description: string,
+  city: string,
+  state: string,
+  is501c3: Is501c3Status,
+  einNumber?: string,
+  // PII: only surfaced to board/admin callers (see nonprofit/nonprofits handlers)
+  contactName: string,
+  contactRole: string,
+  contactEmail: string,
+  contactPhone: string
+}
+
+const nonprofitSchema = new Schema<INonprofit>({
+  name: { type: String, required: true },
+  website: String,
+  description: { type: String, required: true },
+  city: { type: String, required: true },
+  state: { type: String, required: true },
+  is501c3: { type: String, enum: Is501c3Status, required: true },
+  einNumber: String,
+  contactName: { type: String, required: true },
+  contactRole: { type: String, required: true },
+  contactEmail: { type: String, required: true },
+  contactPhone: { type: String, required: true }
+}, MongooseOpts);
+
+export const NonprofitModel = model<INonprofit>('Nonprofit', nonprofitSchema);

--- a/server/lib/models/position-skill.ts
+++ b/server/lib/models/position-skill.ts
@@ -1,0 +1,21 @@
+import { Schema, model, Types } from 'mongoose';
+import { MongooseOpts } from './default-opts';
+import { IPosition } from './position';
+import { SkillImportance } from './enums/skill-importance.enum';
+
+export interface IPositionSkill {
+  _id?: Types.ObjectId,
+  position: IPosition['_id'],
+  code: string, // matches SkillOption.code
+  minimumLevel: number, // same numeric scale as UserSkill.level
+  importance: SkillImportance
+}
+
+const positionSkillSchema = new Schema<IPositionSkill>({
+  position: { type: Schema.Types.ObjectId, required: true, ref: 'Position' },
+  code: { type: String, required: true },
+  minimumLevel: { type: Number, required: true },
+  importance: { type: String, enum: SkillImportance, required: true }
+}, MongooseOpts);
+
+export const PositionSkillModel = model<IPositionSkill>('PositionSkill', positionSkillSchema);

--- a/server/lib/models/position.ts
+++ b/server/lib/models/position.ts
@@ -1,0 +1,21 @@
+import { Schema, model, Types } from 'mongoose';
+import { MongooseOpts } from './default-opts';
+import { IProject } from './project';
+import { Role } from './enums/role.enum';
+
+export interface IPosition {
+  _id?: Types.ObjectId,
+  project: IProject['_id'],
+  role: Role, // same vocabulary as Profile.roles
+  slotCount: number,
+  notes?: string // shown to volunteers on their invitation
+}
+
+const positionSchema = new Schema<IPosition>({
+  project: { type: Schema.Types.ObjectId, required: true, ref: 'Project' },
+  role: { type: String, enum: Role, required: true },
+  slotCount: { type: Number, required: true },
+  notes: String
+}, MongooseOpts);
+
+export const PositionModel = model<IPosition>('Position', positionSchema);

--- a/server/lib/models/project.ts
+++ b/server/lib/models/project.ts
@@ -1,0 +1,48 @@
+import { Schema, model, Types } from 'mongoose';
+import { MongooseOpts } from './default-opts';
+import { INonprofit } from './nonprofit';
+import { IEvent } from './event';
+import { ProjectStatus } from './enums/project-status.enum';
+import { OnsiteContactAvailability } from './enums/onsite-contact-availability.enum';
+import { BrandAssetsStatus } from './enums/brand-assets-status.enum';
+
+export interface IProject {
+  _id?: Types.ObjectId,
+  nonprofit: INonprofit['_id'],
+  event?: IEvent['_id'], // set once the project is accepted and assigned to an event
+  name: string,
+  description: string,
+  problem: string, // what's painful today
+  successCriteria: string,
+  whoUsesIt: string,
+  existingSystem: string,
+  timeline: string,
+  status: ProjectStatus,
+  onsiteContactAvailability: OnsiteContactAvailability,
+  onsiteContactName?: string,
+  brandAssets: BrandAssetsStatus,
+  notes?: string,
+  reference?: string, // tracking id for public form submissions
+  submittedAt?: Date
+}
+
+const projectSchema = new Schema<IProject>({
+  nonprofit: { type: Schema.Types.ObjectId, required: true, ref: 'Nonprofit' },
+  event: { type: Schema.Types.ObjectId, ref: 'Event' },
+  name: { type: String, required: true },
+  description: { type: String, required: true },
+  problem: { type: String, required: true },
+  successCriteria: String,
+  whoUsesIt: String,
+  existingSystem: String,
+  timeline: String,
+  status: { type: String, enum: ProjectStatus, required: true },
+  onsiteContactAvailability: { type: String, enum: OnsiteContactAvailability },
+  onsiteContactName: String,
+  brandAssets: { type: String, enum: BrandAssetsStatus },
+  notes: String,
+  reference: String,
+  submittedAt: Date
+}, MongooseOpts);
+
+export const ProjectModel = model<IProject>('Project', projectSchema);

--- a/server/lib/models/slot.ts
+++ b/server/lib/models/slot.ts
@@ -1,0 +1,28 @@
+import { Schema, model, Types } from 'mongoose';
+import { MongooseOpts } from './default-opts';
+import { IPosition } from './position';
+import { IUser } from './user';
+import { SlotStatus } from './enums/slot-status.enum';
+
+export interface ISlot {
+  _id?: Types.ObjectId,
+  position: IPosition['_id'],
+  user?: IUser['_id'], // unset until a volunteer is invited
+  status: SlotStatus,
+  invitedAt?: Date,
+  respondedAt?: Date,
+  partialDetail?: string,
+  declineReason?: string
+}
+
+const slotSchema = new Schema<ISlot>({
+  position: { type: Schema.Types.ObjectId, required: true, ref: 'Position' },
+  user: { type: Schema.Types.ObjectId, ref: 'User' },
+  status: { type: String, enum: SlotStatus, required: true },
+  invitedAt: Date,
+  respondedAt: Date,
+  partialDetail: String,
+  declineReason: String
+}, MongooseOpts);
+
+export const SlotModel = model<ISlot>('Slot', slotSchema);

--- a/server/lib/models/store.ts
+++ b/server/lib/models/store.ts
@@ -14,6 +14,14 @@ import { IEvent, EventModel } from './event';
 import { IEventAttendance, EventAttendanceModel } from './event-attendance';
 import { create } from 'domain';
 
+// nonprofits & projects
+import { INonprofit, NonprofitModel } from './nonprofit';
+import { IProject, ProjectModel } from './project';
+import { IPosition, PositionModel } from './position';
+import { IPositionSkill, PositionSkillModel } from './position-skill';
+import { ISlot, SlotModel } from './slot';
+import { SlotStatus } from './enums/slot-status.enum';
+
 // Database config
 
 const configureMongoose = async function (log: Logger): Promise<void> {
@@ -225,5 +233,154 @@ export const eventAttendanceStore = {
   },
   delete: async(_id: mongoose.Types.ObjectId) => {
     return await EventAttendanceModel.deleteOne({_id});
+  }
+};
+
+export const nonprofitStore = {
+  list: async(_id: mongoose.Types.ObjectId) => {
+    return await NonprofitModel.findOne({_id});
+  },
+  listAll: async() => {
+    return await NonprofitModel.find();
+  },
+  create: async(nonprofit: INonprofit) => {
+    return await NonprofitModel.create(nonprofit);
+  },
+  update: async(_id: mongoose.Types.ObjectId, nonprofit: INonprofit) => {
+    return await NonprofitModel.updateOne({_id}, nonprofit);
+  },
+  delete: async(_id: mongoose.Types.ObjectId) => {
+    return await NonprofitModel.deleteOne({_id});
+  }
+};
+
+export const projectStore = {
+  list: async(_id: mongoose.Types.ObjectId) => {
+    return await ProjectModel.findOne({_id});
+  },
+  listAll: async() => {
+    return await ProjectModel.find();
+  },
+  listByNonprofit: async(nonprofitId: mongoose.Types.ObjectId) => {
+    return await ProjectModel.find({nonprofit: nonprofitId});
+  },
+  listByEvent: async(eventId: mongoose.Types.ObjectId) => {
+    return await ProjectModel.find({event: eventId});
+  },
+  create: async(project: IProject) => {
+    return await ProjectModel.create(project);
+  },
+  update: async(_id: mongoose.Types.ObjectId, project: IProject) => {
+    return await ProjectModel.updateOne({_id}, project);
+  },
+  delete: async(_id: mongoose.Types.ObjectId) => {
+    return await ProjectModel.deleteOne({_id});
+  }
+};
+
+export const positionStore = {
+  list: async(_id: mongoose.Types.ObjectId) => {
+    return await PositionModel.findOne({_id});
+  },
+  listByProject: async(projectId: mongoose.Types.ObjectId) => {
+    return await PositionModel.find({project: projectId});
+  },
+  // Creates the position along with one open Slot per slotCount, per the
+  // "a Position with slotCount: 2 creates two Slots" rule.
+  create: async(position: IPosition) => {
+    const created = await PositionModel.create(position);
+    const openSlots = Array.from({ length: created.slotCount }, () => ({
+      position: created._id,
+      status: SlotStatus.OPEN
+    })) as ISlot[];
+    await SlotModel.create(openSlots);
+    return created;
+  },
+  update: async(_id: mongoose.Types.ObjectId, position: IPosition) => {
+    return await PositionModel.updateOne({_id}, position);
+  },
+  delete: async(_id: mongoose.Types.ObjectId) => {
+    await SlotModel.deleteMany({position: _id});
+    await PositionSkillModel.deleteMany({position: _id});
+    return await PositionModel.deleteOne({_id});
+  }
+};
+
+export const positionSkillStore = {
+  listByPosition: async(positionId: mongoose.Types.ObjectId) => {
+    return await PositionSkillModel.find({position: positionId});
+  },
+  create: async(positionId: mongoose.Types.ObjectId, positionSkill: IPositionSkill) => {
+    positionSkill.position = positionId;
+    return await PositionSkillModel.create(positionSkill);
+  },
+  update: async(_id: mongoose.Types.ObjectId, positionId: mongoose.Types.ObjectId, positionSkill: IPositionSkill) => {
+    positionSkill.position = positionId;
+    return await PositionSkillModel.updateOne({_id, position: positionId}, positionSkill);
+  },
+  delete: async(_id: mongoose.Types.ObjectId, positionId: mongoose.Types.ObjectId) => {
+    return await PositionSkillModel.deleteOne({_id, position: positionId});
+  },
+  deleteByCode: async(positionId: mongoose.Types.ObjectId, code: string) => {
+    return await PositionSkillModel.deleteOne({position: positionId, code});
+  }
+};
+
+async function getEventIdForPosition(positionId: mongoose.Types.ObjectId): Promise<mongoose.Types.ObjectId | undefined> {
+  const position = await PositionModel.findById(positionId).populate({ path: 'project', select: 'event' });
+  const project = position?.project as unknown as IProject | undefined;
+  return project?.event as mongoose.Types.ObjectId | undefined;
+}
+
+export const slotStore = {
+  list: async(_id: mongoose.Types.ObjectId) => {
+    return await SlotModel.findOne({_id});
+  },
+  listByPosition: async(positionId: mongoose.Types.ObjectId) => {
+    return await SlotModel.find({position: positionId});
+  },
+  listByUser: async(userId: mongoose.Types.ObjectId) => {
+    return await SlotModel.find({user: userId});
+  },
+  update: async(_id: mongoose.Types.ObjectId, slot: ISlot) => {
+    return await SlotModel.updateOne({_id}, slot);
+  },
+  delete: async(_id: mongoose.Types.ObjectId) => {
+    return await SlotModel.deleteOne({_id});
+  },
+  /**
+   * Enforces "one assigned slot per volunteer per event": checks whether the
+   * given user already holds a confirmed slot on any position whose project
+   * is tied to the same event as the given position.
+   */
+  hasConfirmedSlotForEvent: async(
+    userId: mongoose.Types.ObjectId,
+    positionId: mongoose.Types.ObjectId,
+    excludeSlotId?: mongoose.Types.ObjectId
+  ): Promise<boolean> => {
+    const eventId = await getEventIdForPosition(positionId);
+    if (!eventId) {
+      return false; // project not yet assigned to an event; nothing to conflict with
+    }
+
+    const positionsForEvent = await PositionModel.find().populate({
+      path: 'project',
+      match: { event: eventId },
+      select: '_id'
+    });
+    const positionIds = positionsForEvent
+      .filter(p => p.project)
+      .map(p => p._id);
+
+    const query: mongoose.FilterQuery<ISlot> = {
+      user: userId,
+      position: { $in: positionIds },
+      status: { $in: [SlotStatus.CONFIRMED, SlotStatus.CONFIRMED_PARTIAL] }
+    };
+    if (excludeSlotId) {
+      query._id = { $ne: excludeSlotId };
+    }
+
+    return !!(await SlotModel.exists(query));
   }
 };

--- a/server/nonprofit/function.json
+++ b/server/nonprofit/function.json
@@ -1,0 +1,23 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post",
+        "put",
+        "delete"
+      ],
+      "route": "nonprofit/{nonprofitId?}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/nonprofit/index.js"
+}

--- a/server/nonprofit/index.ts
+++ b/server/nonprofit/index.ts
@@ -1,0 +1,139 @@
+import { AzureFunction, Context, HttpRequest } from '@azure/functions';
+import { createErrorResult, createSuccessResult, IHttpResult } from '../lib/core';
+import { nonprofitStore, userStore } from '../lib/models/store';
+import { checkAuthAndConnect } from '../lib/helpers';
+import { EDIT_ALL_NONPROFITS, READ_NONPROFIT_PII } from '../lib/models/enums/user-role.enum';
+import { INonprofit } from '../lib/models/nonprofit';
+import { UserRole } from '../lib/models/enums/user-role.enum';
+
+const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+  // get caller uid from token and connect to DB
+  // eslint-disable-next-line prefer-const
+  let { uid, result } = await checkAuthAndConnect(context, req);
+
+  // result will be non-null if there was an error
+  if (result) {
+    context.res = result;
+    return;
+  }
+
+  switch (req.method) {
+  case 'GET':
+    result = await getNonprofit(context, uid);
+    break;
+  case 'POST':
+    result = await createNonprofit(context, uid);
+    break;
+  case 'PUT':
+    result = await updateNonprofit(context, uid);
+    break;
+  case 'DELETE':
+    result = await deleteNonprofit(context, uid);
+    break;
+  }
+
+  context.res = result;
+};
+
+/** Strips PII fields for callers that aren't board/admin */
+function redact(nonprofit: INonprofit, callerRole: UserRole): Partial<INonprofit> {
+  if (READ_NONPROFIT_PII.includes(callerRole)) {
+    return nonprofit;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { contactName, contactRole, contactEmail, contactPhone, einNumber, ...safe } = nonprofit;
+  return safe;
+}
+
+async function getNonprofit(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  const nonprofitId = context.bindingData.nonprofitId;
+  if (!nonprofitId) {
+    return createErrorResult(404, 'Nonprofit not found', context);
+  }
+
+  const nonprofit = await nonprofitStore.list(nonprofitId);
+  if (!nonprofit) {
+    return createErrorResult(404, 'Nonprofit not found', context);
+  }
+
+  return createSuccessResult(200, redact(nonprofit.toObject(), user.userRole), context);
+}
+
+async function createNonprofit(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  // only board / admins can create nonprofits
+  if (!EDIT_ALL_NONPROFITS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const nonprofitCreate = context.req?.body;
+
+  const nonprofitData = await nonprofitStore.create(nonprofitCreate);
+
+  return createSuccessResult(201, nonprofitData, context);
+}
+
+async function updateNonprofit(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  // only board / admins can update nonprofits
+  if (!EDIT_ALL_NONPROFITS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const nonprofitId = context.bindingData.nonprofitId;
+  if (!nonprofitId) {
+    return createErrorResult(404, 'Nonprofit not found', context);
+  }
+
+  const nonprofit = await nonprofitStore.list(nonprofitId);
+  if (!nonprofit) {
+    return createErrorResult(404, 'Nonprofit not found', context);
+  }
+
+  const nonprofitUpdate = context.req?.body;
+
+  const nonprofitData = await nonprofitStore.update(nonprofitId, nonprofitUpdate);
+
+  return createSuccessResult(200, nonprofitData, context);
+}
+
+async function deleteNonprofit(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  // only board / admins can delete nonprofits
+  if (!EDIT_ALL_NONPROFITS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const nonprofitId = context.bindingData.nonprofitId;
+  if (!nonprofitId) {
+    return createErrorResult(404, 'Nonprofit not found', context);
+  }
+
+  const nonprofit = await nonprofitStore.list(nonprofitId);
+  if (!nonprofit) {
+    return createErrorResult(404, 'Nonprofit not found', context);
+  }
+
+  await nonprofitStore.delete(nonprofitId);
+
+  return createSuccessResult(202, null, context);
+}
+
+export default httpTrigger;

--- a/server/nonprofits/function.json
+++ b/server/nonprofits/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get"
+      ],
+      "route": "nonprofits/{all?}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/nonprofits/index.js"
+}

--- a/server/nonprofits/index.ts
+++ b/server/nonprofits/index.ts
@@ -1,0 +1,51 @@
+import { AzureFunction, Context, HttpRequest } from '@azure/functions';
+import { createErrorResult, createSuccessResult, IHttpResult } from '../lib/core';
+import { checkAuthAndConnect } from '../lib/helpers';
+import { nonprofitStore, userStore } from '../lib/models/store';
+import { READ_NONPROFIT_PII, UserRole } from '../lib/models/enums/user-role.enum';
+import { INonprofit } from '../lib/models/nonprofit';
+
+const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+  // get caller uid from token and connect to DB
+  // eslint-disable-next-line prefer-const
+  let { uid, result } = await checkAuthAndConnect(context, req);
+
+  // result will be non-null if there was an error
+  if (result) {
+    context.res = result;
+    return;
+  }
+
+  switch (req.method) {
+  case 'GET':
+    result = await getNonprofits(context, uid);
+    break;
+  }
+
+  if (result) {
+    context.res = result;
+  }
+};
+
+/** Strips PII fields for callers that aren't board/admin */
+function redact(nonprofit: INonprofit, callerRole: UserRole): Partial<INonprofit> {
+  if (READ_NONPROFIT_PII.includes(callerRole)) {
+    return nonprofit;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { contactName, contactRole, contactEmail, contactPhone, einNumber, ...safe } = nonprofit;
+  return safe;
+}
+
+async function getNonprofits(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  const nonprofits = await nonprofitStore.listAll();
+
+  return createSuccessResult(200, nonprofits.map(n => redact(n.toObject(), user.userRole)), context);
+}
+
+export default httpTrigger;

--- a/server/position-skill/function.json
+++ b/server/position-skill/function.json
@@ -1,0 +1,23 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post",
+        "put",
+        "delete"
+      ],
+      "route": "position/{positionId}/skill/{skillCode?}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/position-skill/index.js"
+}

--- a/server/position-skill/index.ts
+++ b/server/position-skill/index.ts
@@ -1,0 +1,143 @@
+import { AzureFunction, Context, HttpRequest } from '@azure/functions';
+import { createErrorResult, createSuccessResult, IHttpResult } from '../lib/core';
+import { checkAuthAndConnect } from '../lib/helpers';
+import { positionSkillStore, positionStore, userStore } from '../lib/models/store';
+import { EDIT_ALL_POSITIONS } from '../lib/models/enums/user-role.enum';
+
+const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+  // get caller uid from token and connect to DB
+  // eslint-disable-next-line prefer-const
+  let { uid, result } = await checkAuthAndConnect(context, req);
+
+  // result will be non-null if there was an error
+  if (result) {
+    context.res = result;
+    return;
+  }
+
+  switch (req.method) {
+  case 'GET':
+    result = await getPositionSkills(context);
+    break;
+  case 'POST':
+    result = await createPositionSkill(context, uid);
+    break;
+  case 'PUT':
+    result = await updatePositionSkill(context, uid);
+    break;
+  case 'DELETE':
+    result = await deletePositionSkill(context, uid);
+    break;
+  }
+
+  if (result) {
+    context.res = result;
+  }
+};
+
+async function getPositionSkills(context: Context): Promise<IHttpResult> {
+  const positionId = context.bindingData.positionId;
+  if (!positionId) {
+    return createErrorResult(404, 'Position not found', context);
+  }
+
+  const skillCode = context.bindingData.skillCode; // Optional
+
+  let positionSkills = await positionSkillStore.listByPosition(positionId);
+
+  if (skillCode) {
+    positionSkills = positionSkills.filter(s => s.code === skillCode);
+  }
+
+  return createSuccessResult(200, positionSkills, context);
+}
+
+async function createPositionSkill(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  // only board / admins can define required skills for a position
+  if (!EDIT_ALL_POSITIONS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const positionId = context.bindingData.positionId;
+  if (!positionId) {
+    return createErrorResult(404, 'Position not found', context);
+  }
+
+  const position = await positionStore.list(positionId);
+  if (!position) {
+    return createErrorResult(404, 'Position not found', context);
+  }
+
+  const { code, minimumLevel, importance } = context.req?.body ?? {};
+  if (!code || minimumLevel === undefined || !importance) {
+    return createErrorResult(400, 'Position skill data missing expected properties', context);
+  }
+
+  const positionSkillData = await positionSkillStore.create(positionId, { position: positionId, code, minimumLevel, importance });
+
+  return createSuccessResult(201, positionSkillData, context);
+}
+
+async function updatePositionSkill(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  if (!EDIT_ALL_POSITIONS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const positionId = context.bindingData.positionId;
+  if (!positionId) {
+    return createErrorResult(404, 'Position not found', context);
+  }
+
+  const { _id, code, minimumLevel, importance } = context.req?.body ?? {};
+  if (!_id || !code || minimumLevel === undefined || !importance) {
+    return createErrorResult(400, 'Position skill data missing expected properties', context);
+  }
+
+  const updateResult = await positionSkillStore.update(_id, positionId, { position: positionId, code, minimumLevel, importance });
+  if (!updateResult || updateResult.modifiedCount !== 1) {
+    return createErrorResult(404, 'Position skill not found', context);
+  }
+
+  return createSuccessResult(200, { _id, position: positionId, code, minimumLevel, importance }, context);
+}
+
+async function deletePositionSkill(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  if (!EDIT_ALL_POSITIONS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const positionId = context.bindingData.positionId;
+  if (!positionId) {
+    return createErrorResult(404, 'Position not found', context);
+  }
+
+  const skillCode = context.bindingData.skillCode;
+  const skillId = context.req?.body?._id;
+
+  if (skillId) {
+    await positionSkillStore.delete(skillId, positionId);
+  } else if (skillCode) {
+    await positionSkillStore.deleteByCode(positionId, skillCode);
+  } else {
+    return createErrorResult(400, 'Missing skill identifier', context);
+  }
+
+  return createSuccessResult(202, null, context);
+}
+
+export default httpTrigger;

--- a/server/position-slot/function.json
+++ b/server/position-slot/function.json
@@ -1,0 +1,22 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "put",
+        "delete"
+      ],
+      "route": "position/{positionId}/slot/{slotId?}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/position-slot/index.js"
+}

--- a/server/position-slot/index.ts
+++ b/server/position-slot/index.ts
@@ -1,0 +1,130 @@
+import { AzureFunction, Context, HttpRequest } from '@azure/functions';
+import { createErrorResult, createSuccessResult, IHttpResult } from '../lib/core';
+import { checkAuthAndConnect } from '../lib/helpers';
+import { slotStore, userStore } from '../lib/models/store';
+import { EDIT_ALL_SLOTS } from '../lib/models/enums/user-role.enum';
+import { SlotStatus } from '../lib/models/enums/slot-status.enum';
+
+const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+  // get caller uid from token and connect to DB
+  // eslint-disable-next-line prefer-const
+  let { uid, result } = await checkAuthAndConnect(context, req);
+
+  // result will be non-null if there was an error
+  if (result) {
+    context.res = result;
+    return;
+  }
+
+  const user = await userStore.list(uid);
+  if (!user) {
+    context.res = createErrorResult(404, 'User not found', context);
+    return;
+  }
+
+  // this endpoint is for board/admin to manage slots on a position (invite, assign, correct)
+  if (!EDIT_ALL_SLOTS.includes(user.userRole)) {
+    context.res = createErrorResult(403, 'Forbidden', context);
+    return;
+  }
+
+  switch (req.method) {
+  case 'GET':
+    result = await getSlots(context);
+    break;
+  case 'PUT':
+    result = await updateSlot(context);
+    break;
+  case 'DELETE':
+    result = await deleteSlot(context);
+    break;
+  }
+
+  if (result) {
+    context.res = result;
+  }
+};
+
+async function getSlots(context: Context): Promise<IHttpResult> {
+  const positionId = context.bindingData.positionId;
+  if (!positionId) {
+    return createErrorResult(404, 'Position not found', context);
+  }
+
+  const slotId = context.bindingData.slotId; // Optional
+
+  if (slotId) {
+    const slot = await slotStore.list(slotId);
+    if (!slot || String(slot.position) !== String(positionId)) {
+      return createErrorResult(404, 'Slot not found', context);
+    }
+    return createSuccessResult(200, slot, context);
+  }
+
+  const slots = await slotStore.listByPosition(positionId);
+  return createSuccessResult(200, slots, context);
+}
+
+/**
+ * Used to invite a volunteer to an open slot (set user + status: invited),
+ * or to otherwise correct a slot's status as an admin.
+ */
+async function updateSlot(context: Context): Promise<IHttpResult> {
+  const positionId = context.bindingData.positionId;
+  const slotId = context.bindingData.slotId;
+  if (!positionId || !slotId) {
+    return createErrorResult(404, 'Slot not found', context);
+  }
+
+  const slot = await slotStore.list(slotId);
+  if (!slot || String(slot.position) !== String(positionId)) {
+    return createErrorResult(404, 'Slot not found', context);
+  }
+
+  const { user, status, partialDetail, declineReason } = context.req?.body ?? {};
+  if (!status) {
+    return createErrorResult(400, 'Slot data missing expected properties', context);
+  }
+
+  if ((status === SlotStatus.CONFIRMED || status === SlotStatus.CONFIRMED_PARTIAL) && user) {
+    const conflict = await slotStore.hasConfirmedSlotForEvent(user, positionId, slotId);
+    if (conflict) {
+      return createErrorResult(409, 'Volunteer already has a confirmed slot for this event', context);
+    }
+  }
+
+  const update = {
+    position: positionId,
+    user: user ?? slot.user,
+    status,
+    invitedAt: status === SlotStatus.INVITED ? new Date() : slot.invitedAt,
+    respondedAt: [SlotStatus.CONFIRMED, SlotStatus.CONFIRMED_PARTIAL, SlotStatus.DECLINED].includes(status)
+      ? new Date()
+      : slot.respondedAt,
+    partialDetail: partialDetail ?? slot.partialDetail,
+    declineReason: declineReason ?? slot.declineReason
+  };
+
+  const slotData = await slotStore.update(slotId, update);
+
+  return createSuccessResult(200, slotData, context);
+}
+
+async function deleteSlot(context: Context): Promise<IHttpResult> {
+  const positionId = context.bindingData.positionId;
+  const slotId = context.bindingData.slotId;
+  if (!positionId || !slotId) {
+    return createErrorResult(404, 'Slot not found', context);
+  }
+
+  const slot = await slotStore.list(slotId);
+  if (!slot || String(slot.position) !== String(positionId)) {
+    return createErrorResult(404, 'Slot not found', context);
+  }
+
+  await slotStore.delete(slotId);
+
+  return createSuccessResult(202, null, context);
+}
+
+export default httpTrigger;

--- a/server/position/function.json
+++ b/server/position/function.json
@@ -1,0 +1,23 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post",
+        "put",
+        "delete"
+      ],
+      "route": "project/{projectId}/position/{positionId?}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/position/index.js"
+}

--- a/server/position/index.ts
+++ b/server/position/index.ts
@@ -1,0 +1,142 @@
+import { AzureFunction, Context, HttpRequest } from '@azure/functions';
+import { createErrorResult, createSuccessResult, IHttpResult } from '../lib/core';
+import { positionStore, projectStore, userStore } from '../lib/models/store';
+import { checkAuthAndConnect } from '../lib/helpers';
+import { EDIT_ALL_POSITIONS } from '../lib/models/enums/user-role.enum';
+
+const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+  // get caller uid from token and connect to DB
+  // eslint-disable-next-line prefer-const
+  let { uid, result } = await checkAuthAndConnect(context, req);
+
+  // result will be non-null if there was an error
+  if (result) {
+    context.res = result;
+    return;
+  }
+
+  switch (req.method) {
+  case 'GET':
+    result = await getPositions(context);
+    break;
+  case 'POST':
+    result = await createPosition(context, uid);
+    break;
+  case 'PUT':
+    result = await updatePosition(context, uid);
+    break;
+  case 'DELETE':
+    result = await deletePosition(context, uid);
+    break;
+  }
+
+  context.res = result;
+};
+
+async function getPositions(context: Context): Promise<IHttpResult> {
+  const projectId = context.bindingData.projectId;
+  if (!projectId) {
+    return createErrorResult(404, 'Project not found', context);
+  }
+
+  const positionId = context.bindingData.positionId; // Optional
+
+  if (positionId) {
+    const position = await positionStore.list(positionId);
+    if (!position || String(position.project) !== String(projectId)) {
+      return createErrorResult(404, 'Position not found', context);
+    }
+    return createSuccessResult(200, position, context);
+  }
+
+  const positions = await positionStore.listByProject(projectId);
+  return createSuccessResult(200, positions, context);
+}
+
+async function createPosition(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  // only board / admins can create positions
+  if (!EDIT_ALL_POSITIONS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const projectId = context.bindingData.projectId;
+  if (!projectId) {
+    return createErrorResult(404, 'Project not found', context);
+  }
+
+  const project = await projectStore.list(projectId);
+  if (!project) {
+    return createErrorResult(404, 'Project not found', context);
+  }
+
+  const positionCreate = context.req?.body;
+  positionCreate.project = projectId;
+
+  const positionData = await positionStore.create(positionCreate);
+
+  return createSuccessResult(201, positionData, context);
+}
+
+async function updatePosition(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  // only board / admins can update positions
+  if (!EDIT_ALL_POSITIONS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const projectId = context.bindingData.projectId;
+  const positionId = context.bindingData.positionId;
+  if (!projectId || !positionId) {
+    return createErrorResult(404, 'Position not found', context);
+  }
+
+  const position = await positionStore.list(positionId);
+  if (!position || String(position.project) !== String(projectId)) {
+    return createErrorResult(404, 'Position not found', context);
+  }
+
+  const positionUpdate = context.req?.body;
+  positionUpdate.project = projectId;
+
+  const positionData = await positionStore.update(positionId, positionUpdate);
+
+  return createSuccessResult(200, positionData, context);
+}
+
+async function deletePosition(context: Context, userIdent: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  // only board / admins can delete positions
+  if (!EDIT_ALL_POSITIONS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const projectId = context.bindingData.projectId;
+  const positionId = context.bindingData.positionId;
+  if (!projectId || !positionId) {
+    return createErrorResult(404, 'Position not found', context);
+  }
+
+  const position = await positionStore.list(positionId);
+  if (!position || String(position.project) !== String(projectId)) {
+    return createErrorResult(404, 'Position not found', context);
+  }
+
+  await positionStore.delete(positionId);
+
+  return createSuccessResult(202, null, context);
+}
+
+export default httpTrigger;

--- a/server/project/function.json
+++ b/server/project/function.json
@@ -1,0 +1,23 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post",
+        "put",
+        "delete"
+      ],
+      "route": "project/{projectId?}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/project/index.js"
+}

--- a/server/project/index.ts
+++ b/server/project/index.ts
@@ -1,0 +1,128 @@
+import { AzureFunction, Context, HttpRequest } from '@azure/functions';
+import { createErrorResult, createSuccessResult, IHttpResult } from '../lib/core';
+import { projectStore, userStore } from '../lib/models/store';
+import { checkAuthAndConnect } from '../lib/helpers';
+import { EDIT_ALL_PROJECTS } from '../lib/models/enums/user-role.enum';
+import { ProjectStatus } from '../lib/models/enums/project-status.enum';
+
+const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+  // get caller uid from token and connect to DB
+  // eslint-disable-next-line prefer-const
+  let { uid, result } = await checkAuthAndConnect(context, req);
+
+  // result will be non-null if there was an error
+  if (result) {
+    context.res = result;
+    return;
+  }
+
+  switch (req.method) {
+  case 'GET':
+    result = await getProject(context);
+    break;
+  case 'POST':
+    result = await createProject(context, uid);
+    break;
+  case 'PUT':
+    result = await updateProject(context, uid);
+    break;
+  case 'DELETE':
+    result = await deleteProject(context, uid);
+    break;
+  }
+
+  context.res = result;
+};
+
+async function getProject(context: Context): Promise<IHttpResult> {
+  const projectId = context.bindingData.projectId;
+  if (!projectId) {
+    return createErrorResult(404, 'Project not found', context);
+  }
+
+  const project = await projectStore.list(projectId);
+
+  if (!project) {
+    return createErrorResult(404, 'Project not found', context);
+  }
+
+  return createSuccessResult(200, project, context);
+}
+
+async function createProject(context: Context, userIdent: string): Promise<IHttpResult> {
+  // Attempt to acquire current user data
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  // Any authenticated user may submit a project on behalf of a nonprofit (intake);
+  // status/event are always forced regardless of what was submitted, so submissions
+  // always start in the 'interested' state until board/admin acts on them.
+  const projectCreate = context.req?.body;
+  projectCreate.status = ProjectStatus.INTERESTED;
+  projectCreate.event = undefined;
+  projectCreate.submittedAt = new Date();
+
+  const projectData = await projectStore.create(projectCreate);
+
+  return createSuccessResult(201, projectData, context);
+}
+
+async function updateProject(context: Context, userIdent: string): Promise<IHttpResult> {
+  // Attempt to acquire current user data
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  // only board / admins can update a project (accept/reject/archive/edit)
+  if (!EDIT_ALL_PROJECTS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const projectId = context.bindingData.projectId;
+  if (!projectId) {
+    return createErrorResult(404, 'Project not found', context);
+  }
+
+  const project = await projectStore.list(projectId);
+  if (!project) {
+    return createErrorResult(404, 'Project not found', context);
+  }
+
+  const projectUpdate = context.req?.body;
+
+  const projectData = await projectStore.update(projectId, projectUpdate);
+
+  return createSuccessResult(200, projectData, context);
+}
+
+async function deleteProject(context: Context, userIdent: string): Promise<IHttpResult> {
+  // Attempt to acquire current user data
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  // only board / admins can delete projects
+  if (!EDIT_ALL_PROJECTS.includes(user.userRole)) {
+    return createErrorResult(403, 'Forbidden', context);
+  }
+
+  const projectId = context.bindingData.projectId;
+  if (!projectId) {
+    return createErrorResult(404, 'Project not found', context);
+  }
+
+  const project = await projectStore.list(projectId);
+  if (!project) {
+    return createErrorResult(404, 'Project not found', context);
+  }
+
+  await projectStore.delete(projectId);
+
+  return createSuccessResult(202, null, context);
+}
+
+export default httpTrigger;

--- a/server/projects/function.json
+++ b/server/projects/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get"
+      ],
+      "route": "projects/{all?}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/projects/index.js"
+}

--- a/server/projects/index.ts
+++ b/server/projects/index.ts
@@ -1,0 +1,50 @@
+import { AzureFunction, Context, HttpRequest } from '@azure/functions';
+import { Types } from 'mongoose';
+import { createErrorResult, createSuccessResult, IHttpResult } from '../lib/core';
+import { checkAuthAndConnect } from '../lib/helpers';
+import { projectStore, userStore } from '../lib/models/store';
+
+const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+  // get caller uid from token and connect to DB
+  // eslint-disable-next-line prefer-const
+  let { uid, result } = await checkAuthAndConnect(context, req);
+
+  // result will be non-null if there was an error
+  if (result) {
+    context.res = result;
+    return;
+  }
+
+  const nonprofitId = req.query['nonprofitId'];
+  const eventId = req.query['eventId'];
+
+  switch (req.method) {
+  case 'GET':
+    result = await getProjects(context, uid, nonprofitId, eventId);
+    break;
+  }
+
+  if (result) {
+    context.res = result;
+  }
+};
+
+async function getProjects(context: Context, userIdent: string, nonprofitId?: string, eventId?: string): Promise<IHttpResult> {
+  const user = await userStore.list(userIdent);
+  if (!user) {
+    return createErrorResult(404, 'User not found', context);
+  }
+
+  let projects;
+  if (nonprofitId) {
+    projects = await projectStore.listByNonprofit(new Types.ObjectId(nonprofitId));
+  } else if (eventId) {
+    projects = await projectStore.listByEvent(new Types.ObjectId(eventId));
+  } else {
+    projects = await projectStore.listAll();
+  }
+
+  return createSuccessResult(200, projects, context);
+}
+
+export default httpTrigger;

--- a/server/slot/function.json
+++ b/server/slot/function.json
@@ -1,0 +1,21 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "put"
+      ],
+      "route": "user/{userId}/slot/{slotId?}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/slot/index.js"
+}

--- a/server/slot/index.ts
+++ b/server/slot/index.ts
@@ -1,0 +1,106 @@
+import { AzureFunction, Context, HttpRequest } from '@azure/functions';
+import { Types } from 'mongoose';
+import { createErrorResult, createSuccessResult, IHttpResult } from '../lib/core';
+import { checkAuthAndConnect, checkBindingDataUserId } from '../lib/helpers';
+import { slotStore } from '../lib/models/store';
+import { SlotStatus } from '../lib/models/enums/slot-status.enum';
+
+const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+  // get caller uid from token and connect to DB
+  // eslint-disable-next-line prefer-const
+  let { uid, result } = await checkAuthAndConnect(context, req);
+
+  // result will be non-null if there was an error
+  if (result) {
+    context.res = result;
+    return;
+  }
+
+  switch (req.method) {
+  case 'GET':
+    result = await getUserSlots(context, uid);
+    break;
+  case 'PUT':
+    result = await respondToSlot(context, uid);
+    break;
+  }
+
+  if (result) {
+    context.res = result;
+  }
+};
+
+async function getUserSlots(context: Context, userIdent: string): Promise<IHttpResult> {
+  // For MVP we're allowing users to access only their own data
+  const checkResult = await checkBindingDataUserId(context, userIdent);
+  if (checkResult.body.error) {
+    return checkResult;
+  }
+
+  const userId = checkResult.body._id;
+  const slotId = context.bindingData.slotId; // Optional
+
+  if (slotId) {
+    const slot = await slotStore.list(slotId);
+    if (!slot || String(slot.user) !== String(userId)) {
+      return createErrorResult(404, 'Slot not found', context);
+    }
+    return createSuccessResult(200, slot, context);
+  }
+
+  const slots = await slotStore.listByUser(userId);
+  return createSuccessResult(200, slots, context);
+}
+
+/** Lets a volunteer confirm, partially confirm, or decline a slot they've been invited to */
+async function respondToSlot(context: Context, userIdent: string): Promise<IHttpResult> {
+  // For MVP we're allowing users to access only their own data
+  const checkResult = await checkBindingDataUserId(context, userIdent);
+  if (checkResult.body.error) {
+    return checkResult;
+  }
+
+  const userId = checkResult.body._id;
+  const slotId = context.bindingData.slotId;
+  if (!slotId) {
+    return createErrorResult(404, 'Slot not found', context);
+  }
+
+  const slot = await slotStore.list(slotId);
+  if (!slot || String(slot.user) !== String(userId)) {
+    return createErrorResult(404, 'Slot not found', context);
+  }
+
+  if (slot.status !== SlotStatus.INVITED) {
+    return createErrorResult(400, 'Slot is not awaiting a response', context);
+  }
+
+  const { status, partialDetail, declineReason } = context.req?.body ?? {};
+  const respondableStatuses = [SlotStatus.CONFIRMED, SlotStatus.CONFIRMED_PARTIAL, SlotStatus.DECLINED];
+  if (!respondableStatuses.includes(status)) {
+    return createErrorResult(400, 'Invalid response status', context);
+  }
+
+  if (status === SlotStatus.CONFIRMED || status === SlotStatus.CONFIRMED_PARTIAL) {
+    const conflict = await slotStore.hasConfirmedSlotForEvent(userId, slot.position as Types.ObjectId, slotId);
+    if (conflict) {
+      return createErrorResult(409, 'You already have a confirmed slot for this event', context);
+    }
+  }
+
+  const update = {
+    position: slot.position,
+    user: userId,
+    status,
+    invitedAt: slot.invitedAt,
+    respondedAt: new Date(),
+    partialDetail: status === SlotStatus.CONFIRMED_PARTIAL ? partialDetail : slot.partialDetail,
+    declineReason: status === SlotStatus.DECLINED ? declineReason : slot.declineReason
+  };
+
+  const slotData = await slotStore.update(slotId, update);
+
+  return createSuccessResult(200, slotData, context);
+}
+
+export default httpTrigger;


### PR DESCRIPTION
> [!Note]
> Created with Claude using data from this [Data Model Checklist](https://docs.google.com/document/d/1fTJREbAlGtliRIzAr1aEkO7vAjBqW9he/edit#heading=h.a9omjjqgkf9f) for new models/fields that needed to be added.

This pull request introduces a new data model and API layer for managing nonprofits, projects, positions, and volunteer slots, as well as related enums and access control. It adds Mongoose models, store methods, and Azure Functions for CRUD operations on nonprofits, and lays the groundwork for a more structured and permissioned backend. The changes also introduce enums to standardize status and role values across the new models.

**New Models and Data Layer:**

* Added Mongoose models and TypeScript interfaces for `Nonprofit`, `Project`, `Position`, `PositionSkill`, and `Slot`, including their respective enums for status and properties. This provides a structured schema for handling these entities in the database.

* Implemented new store methods in `store.ts` for CRUD operations and queries on nonprofits, projects, positions, position skills, and slots, including logic to enforce business rules (e.g., one confirmed slot per volunteer per event).

**API Layer:**

* Added Azure Function endpoints for single nonprofit (`server/nonprofit/index.ts`) and all nonprofits (`server/nonprofits/index.ts`), with appropriate HTTP method handling and role-based access control for sensitive operations and PII.

**Access Control and Enums:**

* Introduced new role-based permission constants (`EDIT_ALL_NONPROFITS`, `READ_NONPROFIT_PII`, etc.) to centralize and standardize access control for new entities.

**Event Model Update:**

* Extended the `Event` model to include an optional `rsvpDeadline` field, allowing events to specify a cutoff for RSVP changes.

**Other:**

* Minor fix to `checkRequestAuth` to ensure a promise is always returned.